### PR TITLE
Support using custom elements as key components.

### DIFF
--- a/VirtualKeyboard.js
+++ b/VirtualKeyboard.js
@@ -180,12 +180,15 @@ class VirtualKeyboard extends Component {
           [() => keyDown("custom"), null, () => keyDown("back")]
         ];
 
-    // Decide if the element passed as the key is text
-    const keyJsx = keyboardFuncSet[row][column] ? (
-        <Image style={[keyImageDefaultStyle, keyImageStyle]} source={entity} />
-    ) : (
-        <Text style={[keyTextDefaultStyle, keyTextStyle]}>{entity}</Text>
-    );
+    // Decide what type of element is passed as the key
+    let keyJsx;
+    if (React.isValidElement(entity)) {
+      keyJsx = entity;
+    } else if (keyboardFuncSet[row][column]) {
+      keyJsx = <Image style={[keyImageDefaultStyle, keyImageStyle]} source={entity} />;
+    } else {
+      keyJsx = <Text style={[keyTextDefaultStyle, keyTextStyle]}>{entity}</Text>;
+    }
 
     // We want to block keyboard interactions if it has been disabled.
     if (!disabled) {


### PR DESCRIPTION
With this change it is possible to do the following:
```
<VirtualKeyboard
  keyboard={[
    [1, 2, 3],
    [4, 5, 6],
    [7, 8, 9],
    [
      <FontAwesomeIcon color={Colors.black} icon={['fas', 'reset']} size={Sizes.icon} />,
      0,
      <FontAwesomeIcon color={Colors.black} icon={['fas', 'delete']} size={Sizes.icon} />,
    ],
  ]}
  onRef={this.setKeyboardRef}
/>
```

ps: @lukebrandonfarrell Thanks for your effort by making the component available to the community!