### PR TITLE
Add function setText, back. Add custom key style and key disabled option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The back and custom key will pass a sting, either `"back"` or `"custom"` to the 
 
 The `<VirtualKeyboard />` also has a number of functions which can be triggered through refs.
  
+ - `back()` this will execute the back action to delete one character.
+ - `setText(text)` this will set the keyboard text to the given value.
  - `displayMessage(message)` this will create a popup above the
 keyboard displaying the given a message. The style of the popup can be customized through props.
  - `clearMessage()` this will clear the keyboard message dialog.
@@ -60,10 +62,12 @@ The `<VirtualKeyboard />` uses two arrays to allow you to set keys and define cu
 | keyboard        | array         | Yes       | See VirtualKeyboard.js   | 4 x 3 matrix containing the value for each key. See VirtualKeyboard.js.                     |
 | keyboardFunc    | array         | Yes       | See VirtualKeyboard.js   | 4 x 3 matrix containing custom functions for each key. Pass null for no function.       |
 | keyboardCustomKeyImage | number | Yes       | null                 | Image for the custom key (bottom left key)                                              |
+| keyDisabled     | array         | Yes       | See VirtualKeyboard.js   | 4 x 3 matrix containing the disabled value for each key. See VirtualKeyboard.js.                     |
 | keyboardMessageDisplayTime | number | Yes   | 3000                 | Time in milliseconds for the message dialog to automatically clear.                     |
 | vibration       | bool          | Yes       | false                | Key / Tactile vibration enabled                                                         |
 | keyboardStyle   | object        | Yes       | See VirtualKeyboard.js   | Style applied to the keyboard.                                                          |
 | keyboardDisabledStyle | object  | Yes       | See VirtualKeyboard.js   | Style applied when the keyboard is disabled.                                            |
+| keyCustomStyle  | array         | Yes       | See VirtualKeyboard.js   | 4 x 3 matrix containing a custom style for each key. Pass null for default style or to use keyStyle as an override.       |
 | keyStyle        | object        | Yes       | See VirtualKeyboard.js   | Style applied to each key on the keyboard.                                              |
 | keyTextStyle    | object        | Yes       | See VirtualKeyboard.js   | Style applied to the text inside each key.                                              |
 | keyImageStyle   | object        | Yes       | See VirtualKeyboard.js   | Style applied to image in a key. If an image is passed.                                 |

--- a/VirtualKeyboard.js
+++ b/VirtualKeyboard.js
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from "react";
-import { View, Image, Text, StyleSheet, Platform, Vibration, ViewPropTypes } from "react-native";
+import { View, Image, Text, StyleSheet, Platform, TextPropTypes, Vibration, ViewPropTypes } from "react-native";
 import Ripple from "react-native-material-ripple";
 import PropTypes from "prop-types";
 
@@ -156,6 +156,7 @@ class VirtualKeyboard extends Component {
     } = styles;
     /** Props */
     const {
+      keyDisabled,
       keyboardFunc,
       keyboardDisabledStyle,
       vibration,
@@ -164,8 +165,9 @@ class VirtualKeyboard extends Component {
       onPressFunction,
       // Style Props
       keyStyle,
+      keyCustomStyle,
       keyTextStyle,
-      keyImageStyle
+      keyImageStyle,
     } = this.props;
     /** State */
     const { disabled } = this.state;
@@ -187,6 +189,12 @@ class VirtualKeyboard extends Component {
           [null, null, null],
           [() => keyDown("custom"), null, () => keyDown("back")]
         ];
+
+    const _keyStyle = keyCustomStyle && keyCustomStyle[row][column]
+      ? keyCustomStyle[row][column]
+      : keyStyle;
+
+    const _keyDisabled = keyDisabled && keyDisabled[row][column];
 
     // Decide what type of element is passed as the key
     let keyJsx;
@@ -213,8 +221,9 @@ class VirtualKeyboard extends Component {
               onPress={onPressFunction === 'onPress' ? onPress : undefined}
               onPressIn={!onPressFunction || onPressFunction === 'onPressIn' ? onPress : undefined}
               onPressOut={onPressFunction === 'onPressOut' ? onPress : undefined}
-              style={[keyContainerStyle, keyDefaultStyle, keyStyle]}
-          >
+              style={[keyContainerStyle, keyDefaultStyle, _keyStyle]}
+              disabled={entity === null || _keyDisabled}
+              >
             {keyJsx}
           </Ripple>
       );
@@ -226,7 +235,7 @@ class VirtualKeyboard extends Component {
               style={[
                 keyContainerStyle,
                 keyDefaultStyle,
-                keyStyle,
+                _keyStyle,
                 keyboardDisabledDefaultStyle,
                 keyboardDisabledStyle
               ]}
@@ -256,6 +265,22 @@ class VirtualKeyboard extends Component {
         return newString.concat(char);
       }
     }
+  }
+
+  /**
+  * Function used to set the keyboard text
+  */
+  setText(text) {
+    this.setState({ text });
+  }
+
+  /**
+   * Function used to execute back/delete
+   */
+  back() {
+    this.setState({
+      text: this.resolveKeyDownVirtualKeyboard(this.state.text, 'back'),
+    });
   }
 
   /**
@@ -311,12 +336,14 @@ VirtualKeyboard.propTypes = {
   keyboardFunc: PropTypes.array,
   keyboardCustomKeyImage: PropTypes.number,
   keyboardMessageDisplayTime: PropTypes.number,
+  keyDisabled: PropTypes.array,
   vibration: PropTypes.bool,
   // Style props
   keyboardStyle: ViewPropTypes.style,
   keyboardDisabledStyle: ViewPropTypes.style,
   keyStyle: ViewPropTypes.style,
-  keyTextStyle: ViewPropTypes.style,
+  keyCustomStyle: ViewPropTypes.style,
+  keyTextStyle: TextPropTypes.style,
   keyImageStyle: ViewPropTypes.style,
   messageStyle: ViewPropTypes.style,
   messageTextStyle: ViewPropTypes.style,


### PR DESCRIPTION
Hi @lukebrandonfarrell - This is a clean commit for the changes I proposed ..

- Add setText() function
- Add back() function
- Add ability to style a disabled key exclusive of other keys
- Add  ability to style/customize keys exclusive  of other keys

This PR differs from the original in that I replaced clearText() with setText(). Clear can be  accomplished by clearText('') and having setText() is more flexible.