### PR TITLE
Switch propTypes to use deprecated-react-native-prop-types

### DIFF
--- a/VirtualKeyboard.js
+++ b/VirtualKeyboard.js
@@ -4,9 +4,10 @@
  */
 
 import React, { Component } from "react";
-import { View, Image, Text, StyleSheet, Platform, TextPropTypes, Vibration, ViewPropTypes } from "react-native";
+import { View, Image, Text, StyleSheet, Platform, Vibration } from "react-native";
 import Ripple from "react-native-material-ripple";
 import PropTypes from "prop-types";
+import { TextInputPropTypes, ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 const backAsset = require("./back.png");
 
@@ -343,7 +344,7 @@ VirtualKeyboard.propTypes = {
   keyboardDisabledStyle: ViewPropTypes.style,
   keyStyle: ViewPropTypes.style,
   keyCustomStyle: ViewPropTypes.style,
-  keyTextStyle: TextPropTypes.style,
+  keyTextStyle: TextInputPropTypes,
   keyImageStyle: ViewPropTypes.style,
   messageStyle: ViewPropTypes.style,
   messageTextStyle: ViewPropTypes.style,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/lukebrandonfarrell/react-native-screen-keyboard#readme",
   "dependencies": {
+    "deprecated-react-native-prop-types": "^2.2.0",
     "react-native-material-ripple": "git+https://github.com/aspect-apps/react-native-material-ripple.git"
   },
   "keywords": [


### PR DESCRIPTION
This change switches propTypes to deprecated-react-native-prop-types.
I had a bug in my app (after updating to the latest version of RN) that made the app crash because TextPropTypes was used in this library.

PropTypes are deprecated and this library should probably be updated accordingly, but for now I believe this change should buy some time.

This should be the same problem as discussed in issue #20 